### PR TITLE
inetknght/fixes for klight

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,8 @@ jobs:
           command: |
             apt-get update
             apt-get install -y \
-                libboost1.71-dev \
-                libboost-coroutine1.71-dev \
+                libboost1.74-dev \
+                libboost-coroutine1.74-dev \
                 build-essential \
                 cmake \
                 ninja-build \

--- a/cppupnp-config.cmake
+++ b/cppupnp-config.cmake
@@ -4,12 +4,12 @@ project(CPPUPnP VERSION 1.0.0 LANGUAGES CXX)
 
 if (NOT Boost_USE_STATIC_LIBS)
     find_package(Threads REQUIRED)
-    find_package(Boost 1.71 REQUIRED COMPONENTS coroutine system)
+    find_package(Boost 1.74 REQUIRED COMPONENTS coroutine system)
     set(THREAD_LIB "Threads::Threads")
 else()
     # When linking with static Boost, we need to link with libboost_thread.
     find_package(Threads REQUIRED)
-    find_package(Boost 1.71 REQUIRED COMPONENTS thread coroutine system)
+    find_package(Boost 1.74 REQUIRED COMPONENTS thread coroutine system)
     # Boost::thread adds Threads::Threads automatically
     set(THREAD_LIB "Boost::thread")
 endif()

--- a/include/upnp/igd.h
+++ b/include/upnp/igd.h
@@ -128,7 +128,7 @@ public:
      * Discover IGD devices.
      */
     static
-    result<std::vector<igd>> discover(net::executor, net::yield_context);
+    result<std::vector<igd>> discover(net::any_io_executor, net::yield_context);
 
     /*
      * Section 2.4.16 from (IGD:1)
@@ -217,16 +217,16 @@ public:
     ~igd() { stop(); }
 
 private:
-    igd( std::string   uuid
-       , device        upnp_device
-       , std::string   service_id
-       , url_t         url
-       , std::string   urn
-       , net::executor exec);
+    igd( std::string          uuid
+       , device               upnp_device
+       , std::string          service_id
+       , url_t                url
+       , std::string          urn
+       , net::any_io_executor exec);
 
     static
     result<device>
-    query_root_device(net::executor, const url_t&, net::yield_context) noexcept;
+    query_root_device(net::any_io_executor, const url_t&, net::yield_context) noexcept;
 
     using soap_response = beast::http::response<beast::http::string_body>;
 
@@ -236,13 +236,13 @@ private:
                 , net::yield_context) noexcept;
 
 private:
-    std::string   _uuid;
-    device        _upnp_device;
-    std::string   _service_id;
-    url_t         _url;
-    std::string   _urn;
-    net::executor _exec;
-    cancel_t      _cancel;
+    std::string          _uuid;
+    device               _upnp_device;
+    std::string          _service_id;
+    url_t                _url;
+    std::string          _urn;
+    net::any_io_executor _exec;
+    cancel_t             _cancel;
 };
 
 } // namespace upnp

--- a/include/upnp/ssdp.h
+++ b/include/upnp/ssdp.h
@@ -67,7 +67,7 @@ public:
     query(query&&)            = default;
     query& operator=(query&&) = default;
 
-    static result<query> start(net::executor, net::yield_context);
+    static result<query> start(net::any_io_executor, net::yield_context);
 
     // May be called multiple times until error is of type error_code.
     // This let's callers of this function decide what to do when ssdp

--- a/src/condition_variable.h
+++ b/src/condition_variable.h
@@ -26,14 +26,14 @@ class ConditionVariable {
         <WaitEntry, boost::intrusive::constant_time_size<false>>;
 
 public:
-    ConditionVariable(const net::executor&);
+    ConditionVariable(const net::any_io_executor&);
 
     ConditionVariable(const ConditionVariable&) = delete;
     ConditionVariable& operator=(const ConditionVariable&) = delete;
 
     ~ConditionVariable();
 
-    net::executor get_executor() { return _exec; }
+    net::any_io_executor get_executor() { return _exec; }
 
     void notify(const boost::system::error_code& ec
                     = boost::system::error_code());
@@ -42,12 +42,12 @@ public:
     void wait(net::yield_context yield);
 
 private:
-    net::executor _exec;
+    net::any_io_executor _exec;
     IntrusiveList _on_notify;
 };
 
 inline
-ConditionVariable::ConditionVariable(const net::executor& exec)
+ConditionVariable::ConditionVariable(const net::any_io_executor& exec)
     : _exec(exec)
 {
 }

--- a/src/igd.cpp
+++ b/src/igd.cpp
@@ -17,12 +17,12 @@ namespace upnp {
 
 namespace sys = boost::system;
 
-igd::igd( std::string   uuid
-        , device        upnp_device
-        , std::string   service_id
-        , url_t         url
-        , std::string   urn
-        , net::executor exec)
+igd::igd( std::string          uuid
+        , device               upnp_device
+        , std::string          service_id
+        , url_t                url
+        , std::string          urn
+        , net::any_io_executor exec)
     : _uuid(std::move(uuid))
     , _upnp_device(std::move(upnp_device))
     , _service_id(std::move(service_id))
@@ -294,7 +294,7 @@ igd::soap_request( string_view command
 }
 
 /* static */
-result<std::vector<igd>> igd::discover(net::executor exec, net::yield_context yield)
+result<std::vector<igd>> igd::discover(net::any_io_executor exec, net::yield_context yield)
 {
     using namespace std;
 
@@ -375,7 +375,7 @@ result<std::vector<igd>> igd::discover(net::executor exec, net::yield_context yi
 
 /* static */
 result<device>
-igd::query_root_device( net::executor exec
+igd::query_root_device( net::any_io_executor exec
                       , const url_t& url
                       , net::yield_context yield) noexcept
 {

--- a/src/igd.cpp
+++ b/src/igd.cpp
@@ -91,7 +91,7 @@ igd::get_external_address(net::yield_context yield) noexcept
     auto addr = net::ip::make_address(ip_s, ec);
     if (ec) return error::bad_address{};
 
-    return std::move(addr);
+    return addr;
 }
 
 result<igd::map_entry, igd::error::get_generic_port_mapping_entry>
@@ -212,7 +212,7 @@ igd::get_list_of_port_mappings( protocol proto
                           , bool(*oena)});
     }
 
-    return std::move(entries);
+    return entries;
 }
 
 result<void, igd::error::delete_port_mapping>
@@ -290,7 +290,7 @@ igd::soap_request( string_view command
         return E{error::http_status{rs.result()}};
     }
 
-    return std::move(rs);
+    return rs;
 }
 
 /* static */
@@ -370,7 +370,7 @@ result<std::vector<igd>> igd::discover(net::any_io_executor exec, net::yield_con
         }
     }
 
-    return std::move(igds);
+    return igds;
 }
 
 /* static */

--- a/src/igd.cpp
+++ b/src/igd.cpp
@@ -91,7 +91,7 @@ igd::get_external_address(net::yield_context yield) noexcept
     auto addr = net::ip::make_address(ip_s, ec);
     if (ec) return error::bad_address{};
 
-    return addr;
+    return {std::move(addr)};
 }
 
 result<igd::map_entry, igd::error::get_generic_port_mapping_entry>
@@ -212,7 +212,7 @@ igd::get_list_of_port_mappings( protocol proto
                           , bool(*oena)});
     }
 
-    return entries;
+    return {std::move(entries)};
 }
 
 result<void, igd::error::delete_port_mapping>
@@ -290,7 +290,7 @@ igd::soap_request( string_view command
         return E{error::http_status{rs.result()}};
     }
 
-    return rs;
+    return {std::move(rs)};
 }
 
 /* static */
@@ -370,7 +370,7 @@ result<std::vector<igd>> igd::discover(net::any_io_executor exec, net::yield_con
         }
     }
 
-    return igds;
+    return {std::move(igds)};
 }
 
 /* static */
@@ -418,7 +418,7 @@ igd::query_root_device( net::any_io_executor exec
     auto opt_root_dev = device_parse_root(rs.body());
     if (!opt_root_dev) return sys::errc::io_error;
 
-    return std::move(*opt_root_dev);
+    return {std::move(*opt_root_dev)};
 }
 
 void igd::stop() {

--- a/src/ssdp.cpp
+++ b/src/ssdp.cpp
@@ -216,7 +216,7 @@ query::response::parse(string_view lines)
         }
     }
 
-    return std::move(ret);
+    return ret;
 }
 
 void query::state_t::stop() {

--- a/src/ssdp.cpp
+++ b/src/ssdp.cpp
@@ -149,7 +149,7 @@ query::state_t::get_response(net::yield_context yield)
 
     auto r = std::move(_responses.front());
     _responses.pop();
-    return std::move(r.value());
+    return {std::move(r.value())};
 }
 
 /* static */
@@ -216,7 +216,7 @@ query::response::parse(string_view lines)
         }
     }
 
-    return ret;
+    return {std::move(ret)};
 }
 
 void query::state_t::stop() {

--- a/src/ssdp.cpp
+++ b/src/ssdp.cpp
@@ -18,7 +18,7 @@ namespace upnp { namespace ssdp {
 namespace sys = boost::system;
 
 struct query::state_t : std::enable_shared_from_this<state_t> {
-    net::executor _exec;
+    net::any_io_executor _exec;
     net::ip::udp::socket _socket;
     net::steady_timer _timer;
     ConditionVariable _cv;
@@ -29,7 +29,7 @@ struct query::state_t : std::enable_shared_from_this<state_t> {
     bool _stopped = false;
     optional<error_code> _rx_ec;
 
-    state_t(net::executor exec)
+    state_t(net::any_io_executor exec)
         : _exec(std::move(exec))
         , _socket(_exec, net::ip::udp::v4())
         , _timer(_exec)
@@ -231,7 +231,7 @@ query::query(std::shared_ptr<state_t> state)
 {}
 
 /* static */
-result<query> query::start(net::executor exec, net::yield_context yield)
+result<query> query::start(net::any_io_executor exec, net::yield_context yield)
 {
     auto st = std::make_shared<state_t>(exec);
     auto r = st->start(yield);

--- a/src/str/parse_address.h
+++ b/src/str/parse_address.h
@@ -24,7 +24,7 @@ parse_address(string_view s)
 #endif
 
     if (ec) return none;
-    return std::move(addr);
+    return addr;
 }
 
 }} // namespaces

--- a/src/xml.cpp
+++ b/src/xml.cpp
@@ -14,7 +14,7 @@ optional<tree> parse(const std::string& xml_str) {
         ios::stream<ios::array_source> stream(xml_str.c_str(), xml_str.size());
         pt::ptree tree;
         pt::read_xml(stream, tree);
-        return std::move(tree);
+        return tree;
     } catch (std::exception& e) {
         return none;
     }


### PR DESCRIPTION
Hi there! This sounds like a neat project. I wanted to test it out in a private project of mine named `klight`. But I'm using Boost 1.74.0. With these changes, the only compiler warning I see from your project is a header deprecation warning from Boost.

* Update to Boost 1.74.0 (requires updating the executor type)
* Fix compiler warnings about redundant moves.
