### PR TITLE
Add support for multiple network adapters

### DIFF
--- a/include/upnp/igd.h
+++ b/include/upnp/igd.h
@@ -128,7 +128,13 @@ public:
      * Discover IGD devices.
      */
     static
-    result<std::vector<igd>> discover(net::any_io_executor, net::yield_context, const string_view &bind_ip = "");
+    result<std::vector<igd>> discover(net::any_io_executor, const net::ip::address_v4& bind_ip, net::yield_context);
+
+    /*
+     * Discover IGD devices.
+     */
+    static
+    result<std::vector<igd>> discover(net::any_io_executor, net::yield_context);
 
     /*
      * Section 2.4.16 from (IGD:1)

--- a/include/upnp/igd.h
+++ b/include/upnp/igd.h
@@ -128,7 +128,7 @@ public:
      * Discover IGD devices.
      */
     static
-    result<std::vector<igd>> discover(net::any_io_executor, net::yield_context);
+    result<std::vector<igd>> discover(net::any_io_executor, net::yield_context, const string_view &bind_ip = "");
 
     /*
      * Section 2.4.16 from (IGD:1)

--- a/include/upnp/ssdp.h
+++ b/include/upnp/ssdp.h
@@ -67,7 +67,7 @@ public:
     query(query&&)            = default;
     query& operator=(query&&) = default;
 
-    static result<query> start(net::any_io_executor, net::yield_context);
+    static result<query> start(net::any_io_executor, net::yield_context, const string_view &bind_ip);
 
     // May be called multiple times until error is of type error_code.
     // This let's callers of this function decide what to do when ssdp

--- a/include/upnp/ssdp.h
+++ b/include/upnp/ssdp.h
@@ -9,6 +9,7 @@
 #include <boost/range/begin.hpp> // needed by spawn
 #include <boost/range/end.hpp> // needed by spawn
 #include <boost/asio/spawn.hpp>
+#include <boost/asio/ip/address_v4.hpp>
 
 namespace upnp { namespace ssdp {
 
@@ -67,7 +68,7 @@ public:
     query(query&&)            = default;
     query& operator=(query&&) = default;
 
-    static result<query> start(net::any_io_executor, net::yield_context, const string_view &bind_ip);
+    static result<query> start(net::any_io_executor exec, const net::ip::address_v4& bind_ip, net::yield_context yield);
 
     // May be called multiple times until error is of type error_code.
     // This let's callers of this function decide what to do when ssdp

--- a/src/igd.cpp
+++ b/src/igd.cpp
@@ -294,11 +294,12 @@ igd::soap_request( string_view command
 }
 
 /* static */
-result<std::vector<igd>> igd::discover(net::any_io_executor exec, net::yield_context yield)
+result<std::vector<igd>> igd::discover(net::any_io_executor exec, net::yield_context yield
+                                       , const string_view &bind_ip)
 {
     using namespace std;
 
-    auto q = ssdp::query::start(exec, yield);
+    auto q = ssdp::query::start(exec, yield, bind_ip);
     if (!q) return q.error();
     auto& query = q.value();
 

--- a/src/igd.cpp
+++ b/src/igd.cpp
@@ -294,12 +294,13 @@ igd::soap_request( string_view command
 }
 
 /* static */
-result<std::vector<igd>> igd::discover(net::any_io_executor exec, net::yield_context yield
-                                       , const string_view &bind_ip)
+result<std::vector<igd>> igd::discover(net::any_io_executor exec
+                                       , const net::ip::address_v4& bind_ip
+                                       , net::yield_context yield)
 {
     using namespace std;
 
-    auto q = ssdp::query::start(exec, yield, bind_ip);
+    auto q = ssdp::query::start(exec, bind_ip, yield);
     if (!q) return q.error();
     auto& query = q.value();
 
@@ -372,6 +373,11 @@ result<std::vector<igd>> igd::discover(net::any_io_executor exec, net::yield_con
     }
 
     return {std::move(igds)};
+}
+
+result<std::vector<igd>> igd::discover(net::any_io_executor exec, net::yield_context yield)
+{
+    return std::move(discover(exec, net::ip::address_v4::any(), yield));
 }
 
 /* static */

--- a/src/ssdp.cpp
+++ b/src/ssdp.cpp
@@ -41,12 +41,12 @@ struct query::state_t : std::enable_shared_from_this<state_t> {
     result<query::response, query::error::get_response>
     get_response(net::yield_context yield);
 
-    result<void> start(net::yield_context);
+    result<void> start(net::yield_context, const string_view &bind_ip);
 
     void stop();
 };
 
-result<void> query::state_t::start(net::yield_context yield)
+result<void> query::state_t::start(net::yield_context yield, const string_view &bind_ip)
 {
     using udp = net::ip::udp;
     using namespace std::chrono;
@@ -55,7 +55,12 @@ result<void> query::state_t::start(net::yield_context yield)
     _socket.set_option(net::ip::multicast::join_group(_multicast_ep.address()));
 
     error_code ec;
-    _socket.bind(udp::endpoint(net::ip::address_v4::any(), 0), ec);
+    if (bind_ip.empty()) {
+        _socket.bind(udp::endpoint(net::ip::address_v4::any(), 0), ec);
+    } else {
+        _socket.bind(udp::endpoint(net::ip::address_v4::from_string(bind_ip.data()), 0), ec);
+    }
+
     if (ec) return ec;
 
     std::stringstream ss;
@@ -231,10 +236,10 @@ query::query(std::shared_ptr<state_t> state)
 {}
 
 /* static */
-result<query> query::start(net::any_io_executor exec, net::yield_context yield)
+result<query> query::start(net::any_io_executor exec, net::yield_context yield, const string_view &bind_ip)
 {
     auto st = std::make_shared<state_t>(exec);
-    auto r = st->start(yield);
+    auto r = st->start(yield, bind_ip);
     if (!r) return r.error();
     return query{std::move(st)};
 }


### PR DESCRIPTION
Hi!

I've noticed that this library doesn't work so well if multiple network adapters are used.
So if there are multiple network adapters installed, it may happen that boost picks the wrong one
and the program fails as any connection to any client in the other network times out.
This happened to me as I've got (in addition to my default adapter) multiple network adapters for VPNs
installed which leads to the problem described earlier. This maybe only happening on windows, I did not
test any other operating systems.

## Proposal
I've added an optional parameter ``bind_ip`` to ``upnp::igd::discover``, which allows you to
select the ip of the network adapter to bind to and find UPnP Devices in the network
that this ip belongs to.